### PR TITLE
feat: improve performance of entering the context manager

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -74,7 +74,7 @@ async def test_reuse_not_allowed():
     loop = asyncio.get_running_loop()
     future = loop.create_future()
     loop.call_soon(future.set_result, None)
-    manual_interrupt = _Interrupt(loop, future, ValueError, "message")
+    manual_interrupt = _Interrupt(future, ValueError, "message")
 
     async with manual_interrupt:
         await asyncio.sleep(0)


### PR DESCRIPTION
- Make interrupt an alias for _Interrupt
- Avoid fetching the running loop since we do not need it