### PR TITLE
fix: update repo links to use bluetooth-devices

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: ["bdraco"]
+github: ["bluetooth-devices"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,29 +6,29 @@
 
 ### Fix
 
-* Update poetry to v2 + add license to metadata ([#29](https://github.com/bdraco/async_interrupt/issues/29)) ([`fdf0003`](https://github.com/bdraco/async_interrupt/commit/fdf00039068ac2dec1d28efd8fad5b01a0a52c42))
+* Update poetry to v2 + add license to metadata ([#29](https://github.com/bluetooth-devices/async_interrupt/issues/29)) ([`fdf0003`](https://github.com/bluetooth-devices/async_interrupt/commit/fdf00039068ac2dec1d28efd8fad5b01a0a52c42))
 
 ## v1.2.0 (2024-08-21)
 
 ### Feature
 
-* Improve performance of entering the context manager ([#13](https://github.com/bdraco/async_interrupt/issues/13)) ([`fab2218`](https://github.com/bdraco/async_interrupt/commit/fab2218d31383e42fa12e0cb6d76fd611d8ca997))
-* Python 3.13 support ([#14](https://github.com/bdraco/async_interrupt/issues/14)) ([`ec49fee`](https://github.com/bdraco/async_interrupt/commit/ec49fee2bd9233f77a0f5fd597ff06c2db528c92))
+* Improve performance of entering the context manager ([#13](https://github.com/bluetooth-devices/async_interrupt/issues/13)) ([`fab2218`](https://github.com/bluetooth-devices/async_interrupt/commit/fab2218d31383e42fa12e0cb6d76fd611d8ca997))
+* Python 3.13 support ([#14](https://github.com/bluetooth-devices/async_interrupt/issues/14)) ([`ec49fee`](https://github.com/bluetooth-devices/async_interrupt/commit/ec49fee2bd9233f77a0f5fd597ff06c2db528c92))
 
 ## v1.1.2 (2024-06-24)
 
 ### Fix
 
-* Fix license classifier ([#4](https://github.com/bdraco/async_interrupt/issues/4)) ([`f8e3791`](https://github.com/bdraco/async_interrupt/commit/f8e37914c24125ea69690d8bc01ad210a19b8d68))
+* Fix license classifier ([#4](https://github.com/bluetooth-devices/async_interrupt/issues/4)) ([`f8e3791`](https://github.com/bluetooth-devices/async_interrupt/commit/f8e37914c24125ea69690d8bc01ad210a19b8d68))
 
 ## v1.1.1 (2023-07-20)
 
 ### Fix
 
-* Add pytest-asyncio to dev deps to fix tests ([#3](https://github.com/bdraco/async_interrupt/issues/3)) ([`38d268a`](https://github.com/bdraco/async_interrupt/commit/38d268a18f8bc9a7751b11e661e103dda5b886ef))
+* Add pytest-asyncio to dev deps to fix tests ([#3](https://github.com/bluetooth-devices/async_interrupt/issues/3)) ([`38d268a`](https://github.com/bluetooth-devices/async_interrupt/commit/38d268a18f8bc9a7751b11e661e103dda5b886ef))
 
 ## v1.1.0 (2023-07-20)
 
 ### Feature
 
-* Add coverage for external cancel ([#2](https://github.com/bdraco/async_interrupt/issues/2)) ([`e5e21a2`](https://github.com/bdraco/async_interrupt/commit/e5e21a23101e687f94580e089429e64978ee99bb))
+* Add coverage for external cancel ([#2](https://github.com/bluetooth-devices/async_interrupt/issues/2)) ([`e5e21a2`](https://github.com/bluetooth-devices/async_interrupt/commit/e5e21a23101e687f94580e089429e64978ee99bb))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,4 +114,4 @@ $ pytest tests
 
 The deployment should be automated and can be triggered from the Semantic Release workflow in GitHub. The next version will be based on [the commit logs](https://python-semantic-release.readthedocs.io/en/latest/commit-log-parsing.html#commit-log-parsing). This is done by [python-semantic-release](https://python-semantic-release.readthedocs.io/en/latest/index.html) via a GitHub action.
 
-[gh-issues]: https://github.com/bdraco/async_interrupt/issues
+[gh-issues]: https://github.com/bluetooth-devices/async_interrupt/issues

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # async_interrupt
 
 <p align="center">
-  <a href="https://github.com/bdraco/async_interrupt/actions/workflows/ci.yml?query=branch%3Amain">
-    <img src="https://img.shields.io/github/actions/workflow/status/bdraco/async_interrupt/ci.yml?branch=main&label=CI&logo=github&style=flat-square" alt="CI Status" >
+  <a href="https://github.com/bluetooth-devices/async_interrupt/actions/workflows/ci.yml?query=branch%3Amain">
+    <img src="https://img.shields.io/github/actions/workflow/status/bluetooth-devices/async_interrupt/ci.yml?branch=main&label=CI&logo=github&style=flat-square" alt="CI Status" >
   </a>
-  <a href="https://codecov.io/gh/bdraco/async_interrupt">
-    <img src="https://img.shields.io/codecov/c/github/bdraco/async_interrupt.svg?logo=codecov&logoColor=fff&style=flat-square" alt="Test coverage percentage">
+  <a href="https://codecov.io/gh/bluetooth-devices/async_interrupt">
+    <img src="https://img.shields.io/codecov/c/github/bluetooth-devices/async_interrupt.svg?logo=codecov&logoColor=fff&style=flat-square" alt="Test coverage percentage">
   </a>
 </p>
 <p align="center">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,9 @@ requires-python = ">=3.9"
 dynamic = ["classifiers", "dependencies"]
 
 [project.urls]
-"Repository" = "https://github.com/bdraco/async_interrupt"
-"Bug Tracker" = "https://github.com/bdraco/async_interrupt/issues"
-"Changelog" = "https://github.com/bdraco/async_interrupt/blob/main/CHANGELOG.md"
+"Repository" = "https://github.com/bluetooth-devices/async_interrupt"
+"Bug Tracker" = "https://github.com/bluetooth-devices/async_interrupt/issues"
+"Changelog" = "https://github.com/bluetooth-devices/async_interrupt/blob/main/CHANGELOG.md"
 
 [tool.poetry]
 classifiers = [


### PR DESCRIPTION
I have been transferring some of the projects that are under my person GitHub to OHF repos since it was hard for other contributors to help out with projects that were hosted on my personal GitHub. Bluetooth-devices has a lot of people I trust so I picked that org even though the fit is a bit strange.  We could later transfer it to home-assistant-libs if desired.